### PR TITLE
Options to Open with Active File

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -23,6 +23,12 @@
 		}
 	};
 
+	document.addEventListener("DOMContentLoaded", function(e) {
+		vscode.postMessage({
+			command: 'refresh-back-forward-buttons',
+		});
+	});
+
 	document.getElementById('back').onclick = function () {
 		vscode.postMessage({
 			command: 'go-back',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 	"activationEvents": [
 		"onCommand:liveserver.start",
 		"onCommand:liveserver.end",
-		"onCommand:liveserver.start.withpreview",
+		"onCommand:liveserver.start.preview.atIndex",
+		"onCommand:liveserver.start.preview.atActiveFile",
 		"onWebviewPanel:browserPreview"
 	],
 	"main": "./out/extension.js",
@@ -29,14 +30,28 @@
 				"title": "LiveServer v2: Start Development Server"
 			},
 			{
-				"command": "liveserver.start.withpreview",
-				"title": "LiveServer v2: Show Preview"
+				"command": "liveserver.start.preview.atIndex",
+				"title": "LiveServer v2: Show Preview at Index"
+			},
+			{
+				"command": "liveserver.start.preview.atActiveFile",
+				"title": "LiveServer v2: Show Preview at Active File",
+				"icon": "$(open-preview)"
 			},
 			{
 				"command": "liveserver.end",
 				"title": "LiveServer v2: Close Development Server"
 			}
-		]
+		],
+		"menus": {
+			"editor/title": [
+				{
+					"command": "liveserver.start.preview.atActiveFile",
+					"when": "editorLangId == html && !notebookEditorFocused",
+					"group": "navigation"
+				}
+			]
+		}
 	},
 	"scripts": {
 		"vscode:prepublish": "webpack --mode production",

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -19,24 +19,28 @@ export class BrowserPreview extends Disposable {
 		this._panel.dispose();
 	}
 
-	public reveal(column: number): void {
+	public reveal(column: number, file = "/"): void {
+		this.goToFile(file);
+		this.handleNewPageLoad(file);
 		this._panel.reveal(column);
 	}
 
 	public updatePortNums(port: number, wsPort: number): void {
 		this._port = port;
 		this._wsPort = wsPort;
-		this.goToFile('/');
+		this.reloadWebview();
 	}
 
 	private get currentAddress() {
 		return this._panel.title;
 	}
+	
 	constructor(
 		panel: vscode.WebviewPanel,
 		extensionUri: vscode.Uri,
 		port: number,
-		wsPort: number
+		wsPort: number,
+		initialFile: string,
 	) {
 		super();
 
@@ -49,9 +53,9 @@ export class BrowserPreview extends Disposable {
 		this.updateForwardBackArrows();
 
 		// Set the webview's html content at index.html
-		this.goToFile('/');
-		this._pageHistory?.addHistory('/');
-		this.setPanelTitle('/');
+		this.goToFile(initialFile);
+		this._pageHistory?.addHistory(initialFile);
+		this.setPanelTitle(initialFile);
 
 		// Listen for when the panel is disposed
 		// This happens when the user closes the panel or when the panel is closed programmatically
@@ -108,6 +112,10 @@ export class BrowserPreview extends Disposable {
 		return `http://127.0.0.1:${this._port}`;
 	}
 
+	private reloadWebview() {
+		this.goToFile(this._panel.title);
+	}
+	
 	private handleOpenBrowser(givenURL: string) {
 		const urlString =
 			givenURL == '' ? this.constructAddress(this._panel.title) : givenURL;
@@ -119,6 +127,7 @@ export class BrowserPreview extends Disposable {
 		this.goToFile(this.currentAddress);
 		this.updateForwardBackArrows();
 	}
+
 	private updateForwardBackArrows(): void {
 		const navigationStatus = this._pageHistory.currentCommands;
 		for (const i in navigationStatus) {

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -88,15 +88,8 @@ export class BrowserPreview extends Disposable {
 						// called from main.js in the case where the target is non-injectable
 						this.handleNewPageLoad(message.text);
 						return;
-				}
-			})
-		);
-
-		// Update the content based on view changes
-		this._register(
-			this._panel.onDidChangeViewState((e) => {
-				if (this._panel.visible) {
-					this.updateForwardBackArrows();
+					case 'refresh-back-forward-buttons':
+						this.updateForwardBackArrows();
 				}
 			})
 		);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,18 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('liveserver.start.withpreview', () => {
+		vscode.commands.registerCommand('liveserver.start.preview.atIndex', () => {
 			manager.createOrShowPreview();
+		})
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('liveserver.start.preview.atActiveFile', () => {
+			const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+			const activeFile = vscode.window.activeTextEditor?.document.fileName;
+
+			const relativeActiveFile = activeFile?.substr(workspaceFolder?.length ?? 0).replace(/\\/gi, "/");
+			manager.createOrShowPreview(undefined,relativeActiveFile);
 		})
 	);
 
@@ -28,8 +38,7 @@ export function activate(context: vscode.ExtensionContext) {
 			async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel) {
 				// Reset the webview options so we use latest uri for `localResourceRoots`.
 				webviewPanel.webview.options = getWebviewOptions(context.extensionUri);
-				manager.createOrShowPreview(webviewPanel);
-				// bp.BrowserPreview.revive(webviewPanel, context.extensionUri);
+				manager.createOrShowPreview(webviewPanel,webviewPanel.title);
 			},
 		});
 	}

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -33,14 +33,15 @@ export class Manager extends Disposable {
 	}
 
 	public createOrShowPreview(
-		panel: vscode.WebviewPanel | undefined = undefined
+		panel: vscode.WebviewPanel | undefined = undefined,
+		file = "/"
 	): void {
 		const currentColumn = vscode.window.activeTextEditor?.viewColumn ?? 1;
 		const column = currentColumn + 1;
 
 		// If we already have a panel, show it.
 		if (this.currentPanel) {
-			this.currentPanel.reveal(column);
+			this.currentPanel.reveal(column, file);
 			return;
 		}
 
@@ -58,7 +59,8 @@ export class Manager extends Disposable {
 			panel,
 			this._extensionUri,
 			this._serverPort,
-			this._serverWSPort
+			this._serverWSPort,
+			file
 		);
 
 		this.currentPanel.onDispose(() => {

--- a/src/server/mainServer.ts
+++ b/src/server/mainServer.ts
@@ -72,7 +72,6 @@ export class MainServer extends Disposable {
 				res.end();
 				return;
 			}
-			console.log(req.url);
 			const endOfPath = req.url.lastIndexOf('?');
 			const URLPathName =
 				endOfPath == -1 ? req.url : req.url.substring(0, endOfPath);


### PR DESCRIPTION
Added in this PR:
- HTML files have a button that allows you to open a preview for it.
![image](https://user-images.githubusercontent.com/31675041/121247918-04ed2c80-c860-11eb-886a-82c1917d78ea.png)

- `Open Preview` is now split into an option to open the active file or open from the index.
- Re-opening a window with an open preview will re-serialize with at the same page.
- The webview error thrown in the console when closing the preview is fixed.

Closes https://github.com/microsoft/vscode/issues/125775
